### PR TITLE
Add CWE reference, fix error (send is low level!)

### DIFF
--- a/docs/SCWE/SCSVS-CODE/SCWE-048.md
+++ b/docs/SCWE/SCSVS-CODE/SCWE-048.md
@@ -12,7 +12,9 @@ status: new
 ---
 
 ## Relationships
-- CWE-390: Detection of Error Condition Without Action  
+- CWE-252: Unchecked Return Value
+  [https://cwe.mitre.org/data/definitions/252.html](https://cwe.mitre.org/data/definitions/252.html)
+- CWE-390: Detection of Error Condition Without Action
   [https://cwe.mitre.org/data/definitions/390.html](https://cwe.mitre.org/data/definitions/390.html)
 
 ## Description
@@ -20,18 +22,18 @@ Unchecked call return value vulnerabilities occur when a contract fails to valid
 
 ## Remediation
 - **Check return values:** Always verify the success of low-level calls.  
-- **Use higher-level abstractions:** Prefer `transfer` or `send` over `call` for sending Ether, as they revert on failure. 
+- **Use higher-level abstractions:** Prefer method calls or, if you are confident that 2300 gas are sufficient for the recipient to handle the transfer, `transfer` over `call`, as they revert on failure. 
 
 ## Examples
 
 ### Vulnerable Contract Example
 
 ```solidity
-pragma solidity ^0.4.0;
+pragma solidity ^0.8.0;
 
 contract UncheckedCall {
     function sendEther(address _recipient) public payable {
-        _recipient.call.value(msg.value)(); // Unchecked call, no error handling
+        _recipient.call{value: msg.value}(""); // Unchecked call, no error handling
     }
 }
 ```


### PR DESCRIPTION
Addresses issue #23.

- Add reference to CWE-252
- Fix error in remedies: send is a low-level call as well, at least in the sense that the return value is not automatically checked. Recommending its use instead of call doesn't seem to make sense.
- `transfer` should not be recommended without caution, as it restricts the usability of the contract. The trend goes towards code-managed accounts, and even though 2300 gas may be sufficient today, it may fail tomorrow.
- Use recent code samples whenever possible, also for the faulty contract. If this is not possible, because the problem is tied to an ancient compiler version, consider omitting the weakness from the registry.